### PR TITLE
Add Mydentify AI crawler access checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[LLMrefs](https://llmrefs.com)** – Generative AI search analytics tracker for brand visibility, rank, and citations across major answer engines.
 - **[Lorelight](https://lorelight.ai/)** – AI visibility analytics and monitoring.
 - **[ModelMonitor](https://modelmonitor.ai/brands/activity-monitor)** – Monitors mentions across 50+ models (OpenAI, Anthropic, Grok, etc.); API + webhooks for reputation teams.
+- **[Mydentify — Can AI Bots Read My Site?](https://mydentify.com/tools/ai-crawler-access-checker)** – Free checker that tests whether AI crawlers can reach a site’s pages and explains robots.txt, headers, and page-level access signals.
 - **[Nuggt](https://beta.nuggt.io/)** – SEO agency platform focused on generative search performance.
 - **[Otterly.AI](https://otterly.ai)** – Real-time dashboard for Google AI Overviews, ChatGPT & Perplexity; tracks citations, sentiment and prompt-level share of voice. Starts at $29 / mo after a 7-day trial.
 - **[Peec AI](https://peec.ai)** – Marketing-team console benchmarking ChatGPT, Claude, Gemini & Perplexity visibility across countries; includes competitor leaderboards and scheduled PDF exports.


### PR DESCRIPTION
Adds **Mydentify — Can AI Bots Read My Site?** to the alphabetical GEO/AEO tools list.

- Public URL: https://mydentify.com/tools/ai-crawler-access-checker
- The route is live, self-canonical, and declares `index, follow`.
- It is a free checker that explains whether AI crawlers can reach a site’s pages using robots.txt, headers, and page-level access signals.

This is a self-submission; I maintain Mydentify. It is one tool, placed alphabetically between ModelMonitor and Nuggt, and requests no reciprocal link, vote, review, or other engagement.