### PR TITLE
Add Seeno (AI brand visibility platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Search Visibility](https://search-visibility.ai)** – Tracks brand mentions across ChatGPT, Gemini, Claude, and more AI models.
 - **[Searchify](https://searchify.ai)** – AI Visibility tracking and optimization platform built for SMBs. Pricing starts at $149/mo with optional full-service "done for you" add-ons.
 - **[Seerly (AIRO)](https://seerly.app/)** – AI search optimization platform.
+- **[Seeno](https://seeno.ai)** – Vertical AI-visibility platform for real estate, hotels, law firms and B2B SaaS. Tracks ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews, query-based pricing from $149/mo, free audit.
 - **[Senso.ai](https://senso.ai)** – Detects content gaps and keeps your messaging consistent across AI surfaces; integrates with CMS for auto-publishing.
 - **[Share of Model](https://www.jellyfish.com/en-us/news/jellyfish-launches-the-share-of-model-platform/)** – Jellyfish’s metric & platform measuring *proportional* mentions across LLMs—the “share of voice” for AI.
 - **[Tesseract](https://tesseract.adlift.com/)** – Tracks and analyses brand visibility across LLMs with AI Overview.


### PR DESCRIPTION
This PR adds Seeno (https://seeno.ai) to the tools list.

Disclosure: I am the founder. Seeno is an AI brand visibility platform that tracks how brands appear in answers from ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews. It focuses on vertical benchmarks (real estate, hotels, law firms, B2B SaaS) and publishes open industry research built on thousands of scanned AI answers: https://seeno.ai/research

Placement follows the existing ordering and formatting of the list. Happy to adjust wording.