### PR TITLE
Add Mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[LLMrefs](https://llmrefs.com)** – Generative AI search analytics tracker for brand visibility, rank, and citations across major answer engines.
 - **[Lorelight](https://lorelight.ai/)** – AI visibility analytics and monitoring.
 - **[ModelMonitor](https://modelmonitor.ai/brands/activity-monitor)** – Monitors mentions across 50+ models (OpenAI, Anthropic, Grok, etc.); API + webhooks for reputation teams.
+- **[Mentioned](https://mentioned.to)** – Done-for-you Reddit growth for GEO. Finds the Reddit threads ranking on Google and cited by LLMs for your keywords, places your brand in them via managed accounts, and reports share of voice vs competitors.
 - **[Nuggt](https://beta.nuggt.io/)** – SEO agency platform focused on generative search performance.
 - **[Otterly.AI](https://otterly.ai)** – Real-time dashboard for Google AI Overviews, ChatGPT & Perplexity; tracks citations, sentiment and prompt-level share of voice. Starts at $29 / mo after a 7-day trial.
 - **[Peec AI](https://peec.ai)** – Marketing-team console benchmarking ChatGPT, Claude, Gemini & Perplexity visibility across countries; includes competitor leaderboards and scheduled PDF exports.


### PR DESCRIPTION
Adds [Mentioned](https://mentioned.to) in alphabetical position, matching the existing entry format.

Most of this list tracks and measures AI visibility. Mentioned works the other side of it — it targets Reddit specifically, which is one of the largest citation sources for answer engines (roughly 47% of Perplexity citations), finds the threads already ranking on Google for a brand's keywords, places the brand in them via managed accounts, and reports share of voice against competitors.

One line added, no other changes.