### PR TITLE
Add seo-geo-skill (open-source GEO/SEO audit skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Searchify](https://searchify.ai)** – AI Visibility tracking and optimization platform built for SMBs. Pricing starts at $149/mo with optional full-service "done for you" add-ons.
 - **[Seerly (AIRO)](https://seerly.app/)** – AI search optimization platform.
 - **[Senso.ai](https://senso.ai)** – Detects content gaps and keeps your messaging consistent across AI surfaces; integrates with CMS for auto-publishing.
+- **[seo-geo-skill](https://github.com/asale-ai/seo-geo-skill)** – Open-source (MIT) agent skills that audit a site for GEO and classic SEO from inside a coding agent; AI-crawler reachability, passage-level citability scoring, llms.txt and schema generation. Single Rust binary, no Python; most checks run with no account or API key.
 - **[Share of Model](https://www.jellyfish.com/en-us/news/jellyfish-launches-the-share-of-model-platform/)** – Jellyfish’s metric & platform measuring *proportional* mentions across LLMs—the “share of voice” for AI.
 - **[Tesseract](https://tesseract.adlift.com/)** – Tracks and analyses brand visibility across LLMs with AI Overview.
 - **[Trackerly.ai](https://trackerly.ai)** – Daily brand-mention tracker covering multiple LLMs in 20+ languages; auto-builds PDF or live-link reports for agencies and in-house teams.


### PR DESCRIPTION
Adds one entry, in alphabetical order, between Senso.ai and Share of Model.

Unlike most of the list, this one is not a hosted dashboard - it is an open-source (MIT) set of agent skills that run the GEO/AEO audit locally from inside a coding agent (Claude Code, Codex, Cursor and 75+ others via npx skills). The execution layer is a single Rust static binary, so there is no Python or pip in the install path.

What it checks: AI-crawler reachability against robots.txt, passage-level citability scoring for answer engines, llms.txt validation and generation, structured-data detection and generation, citation-gap analysis, plus the classic technical SEO surface. Most of it runs with no account and no API key; Search Console, PageSpeed, Moz and DataForSEO are optional.

Disclosure: I am the author. Format follows CONTRIBUTING.md, single suggestion in this PR.