### PR TITLE
Add Asked Thrice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[AI Rank Tracker](https://airank.dejan.ai)** – DejanSEO’s experimental tool mining language-association graphs to show which entities LLMs most connect to your brand.
 - **[Am I on AI?](https://amionai.com)** – Simple checker that shows how often ChatGPT recommends your business and offers priority fixes; weekly trend emails.
 - **[AppearOnAI](https://appearonai.com)** – Action-oriented audit + playbook to boost site visibility inside ChatGPT, Claude & Gemini answers.
+- **[Asked Thrice](https://askedthrice.com)** – One-time audit instead of a subscription: derives buyer-intent questions from your own site, runs them against the OpenAI, Gemini and Claude APIs, and returns counts with the raw answers as evidence plus a 14-day publishing plan. Free first run, no signup; full report $9 one-time; $29.99 lifetime pass covers every re-run.
 - **[AthenaHQ](https://athenahq.ai)** – Analysed 3M+ AI responses; delivers free visibility report and a GEO playbook focused on mid-market SaaS.
 - **[Attensira](https://attensira.com)** – AI search visibility tracking and optimization platform; monitors prompts, content creation, and competitor comparison.
 - **[AutoGEO](https://github.com/cxcscmu/AutoGEO)** – An automated framework that learns what generative search engines prefer and rewrites content accordingly. It achieves up to 50% improvement in generative search visibility while maintaining engine utility. 1-minute setup for API version with no additional service fees.


### PR DESCRIPTION
Adds [Asked Thrice](https://askedthrice.com) to the list, in alphabetical order between AppearOnAI and AthenaHQ, matching the list's entry format.

**Disclosure:** I am the founder.

**Note on the name:** this PR was opened on 2026-08-24 as "LLM Audit". The product was renamed to Asked Thrice on 2026-08-30 and the entry is updated accordingly. Same tool, same people. The reason for the rename is that "LLM audit" is a generic phrase shared with three unrelated companies, so an assistant asked about it described someone else. The new name comes from the method: three runs per model, because asking once does not prove anything.

Vendor-reported facts, consistent with the list's quick note: free first run without signup, full report $9 one-time, $29.99 lifetime pass, no subscription; measures the OpenAI, Gemini and Claude model APIs; methodology is public at https://askedthrice.com/methodology and the results are reported as counts with their total rather than a single visibility score.

Checked against the contribution guidelines: searched the list first, it is answer-engine optimization software, individual PR, format and ordering match the neighbours.