### PR TITLE
Add NostalgAI Answer-Readiness Scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[LLMrefs](https://llmrefs.com)** – Generative AI search analytics tracker for brand visibility, rank, and citations across major answer engines.
 - **[Lorelight](https://lorelight.ai/)** – AI visibility analytics and monitoring.
 - **[ModelMonitor](https://modelmonitor.ai/brands/activity-monitor)** – Monitors mentions across 50+ models (OpenAI, Anthropic, Grok, etc.); API + webhooks for reputation teams.
+- **[NostalgAI](https://nostalgai.us/)** – Free deterministic answer-readiness scanner with 16 evidence-backed checks across public-site identity, crawler access, attributable proof and decision support; an optional fixed-price Fix Pack turns gaps into publish-ready content and JSON-LD. Does not query models or predict citations.
 - **[Nuggt](https://beta.nuggt.io/)** – SEO agency platform focused on generative search performance.
 - **[Otterly.AI](https://otterly.ai)** – Real-time dashboard for Google AI Overviews, ChatGPT & Perplexity; tracks citations, sentiment and prompt-level share of voice. Starts at $29 / mo after a 7-day trial.
 - **[Peec AI](https://peec.ai)** – Marketing-team console benchmarking ChatGPT, Claude, Gemini & Perplexity visibility across countries; includes competitor leaderboards and scheduled PDF exports.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[LLMrefs](https://llmrefs.com)** – Generative AI search analytics tracker for brand visibility, rank, and citations across major answer engines.
 - **[Lorelight](https://lorelight.ai/)** – AI visibility analytics and monitoring.
 - **[ModelMonitor](https://modelmonitor.ai/brands/activity-monitor)** – Monitors mentions across 50+ models (OpenAI, Anthropic, Grok, etc.); API + webhooks for reputation teams.
-- **[NostalgAI](https://nostalgai.us/)** – Free deterministic answer-readiness scanner with 16 evidence-backed checks across public-site identity, crawler access, attributable proof and decision support; an optional fixed-price Fix Pack turns gaps into publish-ready content and JSON-LD. Does not query models or predict citations.
+- **[NostalgAI](https://nostalgai.us/scanner)** – Free deterministic answer-readiness scanner with 16 evidence-backed checks across public-site identity, crawler access, attributable proof and decision support; an optional fixed-price Fix Pack turns gaps into publish-ready content and JSON-LD. Does not query models or predict citations.
 - **[Nuggt](https://beta.nuggt.io/)** – SEO agency platform focused on generative search performance.
 - **[Otterly.AI](https://otterly.ai)** – Real-time dashboard for Google AI Overviews, ChatGPT & Perplexity; tracks citations, sentiment and prompt-level share of voice. Starts at $29 / mo after a 7-day trial.
 - **[Peec AI](https://peec.ai)** – Marketing-team console benchmarking ChatGPT, Claude, Gemini & Perplexity visibility across countries; includes competitor leaderboards and scheduled PDF exports.
@@ -72,3 +72,4 @@ These can help you ride the AI wave to success rather than drown in it.
 ---
 
 _Seen something missing or out-of-date? Open a PR or file an issue—please include a public URL so we can verify and add it._
+


### PR DESCRIPTION
Adds NostalgAI as an AEO/GEO audit tool. It checks observable website signals and explicitly does not claim to measure model visibility or predict citations. I am the maker; this is a self-submission.