### PR TITLE
Add Ooky

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Lorelight](https://lorelight.ai/)** – AI visibility analytics and monitoring.
 - **[ModelMonitor](https://modelmonitor.ai/brands/activity-monitor)** – Monitors mentions across 50+ models (OpenAI, Anthropic, Grok, etc.); API + webhooks for reputation teams.
 - **[Nuggt](https://beta.nuggt.io/)** – SEO agency platform focused on generative search performance.
+- **[Ooky](https://ooky.ai)** – Tracks brand mentions, sentiment and rank across ChatGPT, Gemini & Perplexity (Claude on Enterprise); serves a distilled, parity-checked version of your pages to AI crawlers via Cloudflare Worker, SDK or WordPress plugin. Free plan; paid from Starter.
 - **[Otterly.AI](https://otterly.ai)** – Real-time dashboard for Google AI Overviews, ChatGPT & Perplexity; tracks citations, sentiment and prompt-level share of voice. Starts at $29 / mo after a 7-day trial.
 - **[Peec AI](https://peec.ai)** – Marketing-team console benchmarking ChatGPT, Claude, Gemini & Perplexity visibility across countries; includes competitor leaderboards and scheduled PDF exports.
 - **[Peekaboo](https://aipeekaboo.com)** – Competitor-insights engine showing which rivals capture your traffic in AI chat and by how much; geo drill-downs included.


### PR DESCRIPTION
Adds Ooky (https://ooky.ai), an AI brand-visibility platform: prompt tracking across ChatGPT, Gemini and Perplexity (Claude on the Enterprise plan), plus delivery of distilled HTML/JSON-LD/llms.txt to AI crawlers at the edge. Active, launched 2026, free plan available.

WordPress plugin: https://wordpress.org/plugins/ooky-ai-visibility/
npm: https://www.npmjs.com/package/@ooky/sdk

Disclosure: I am the founder. Happy to adjust the wording or drop it if it does not fit.